### PR TITLE
links.t fails on Windows

### DIFF
--- a/t/links.t
+++ b/t/links.t
@@ -1,11 +1,12 @@
 use strict;
 
 use Test::Builder::Tester;
-use Test::More tests => 37;
+use Test::More;
 use Test::File;
 
 my $can_symlink = eval { symlink("",""); 1 };
 plan skip_all => "This system does't do symlinks" unless $can_symlink;
+plan tests => 37;
 
 my $test_directory = 'test_files';
 SKIP: {


### PR DESCRIPTION
One possible fix for "You tried to plan twice at t\links.t line 8."
