### PR TITLE
Work around perl bug regarding line numbers

### DIFF
--- a/t/line_counters.t
+++ b/t/line_counters.t
@@ -176,14 +176,15 @@ test_diag(
 file_line_count_isnt( $file, $lines );
 test_test();
 
-$name = "$file line count is between [$linesp] and [@{[$linesp+1]}] lines";
+my $linespp = $linesp + 1;
+$name = "$file line count is between [$linesp] and [$linespp] lines";
 test_out( "not ok 1 - $name" );
 test_diag(
-	"Expected a line count between [$linesp] and [@{[$linesp+1]}] in [$file], but got [$lines] lines!\n" .
+	"Expected a line count between [$linesp] and [$linespp] in [$file], but got [$lines] lines!\n" .
 	"#   Failed test '$name'\n" .
-	"#   at $0 line " . line_num(+4) . "."
+	"#   at $0 line " . line_num(+5) . "."
 	);
-file_line_count_between( $file, $linesp, $linesp + 1 );
+file_line_count_between( $file, $linesp, $linespp );
 test_test();
 }
 


### PR DESCRIPTION
In perl 5.18 and earlier, caller will return an incorrect line number when used in an expression with the @{[...]} idiom.  Avoid using the idiom to fix the reported line numbers.  Fixes rt#89849.
