### PR TITLE
add file_mode_has and file_mode_hasnt

### DIFF
--- a/lib/Test/File.pm
+++ b/lib/Test/File.pm
@@ -41,7 +41,7 @@ Test::File -- test file attributes
 
 =head1 SYNOPSIS
 
-use Test::File;
+  use Test::File;
 
 =head1 DESCRIPTION
 

--- a/t/test_files.t
+++ b/t/test_files.t
@@ -74,10 +74,52 @@ test_test();
 
 {
 my $s = Test::File::_win32()
+	? "# skip file_mode_has doesn't work on Windows!"
+	: "- executable mode has all bits of 0100";
+test_out( "ok 1 $s" );
+file_mode_has( 'executable', 0100 );
+test_test();
+}
+
+{
+my $s = Test::File::_win32()
+	? "# skip file_mode_has doesn't work on Windows!"
+	: "- executable mode has all bits of 0111";
+test_out( "not ok 1 $s" );
+test_diag("File [executable] mode is missing component 0011!");
+test_diag("  Failed test 'executable mode has all bits of 0111'");
+test_diag("  at " . __FILE__ . " line " . (__LINE__+1) . ".");
+file_mode_has( 'executable', 0111 );
+test_test();
+}
+
+{
+my $s = Test::File::_win32()
 	? "# skip file_mode_isnt doesn't work on Windows!"
 	: "- executable mode is not 0200";
 test_out( "ok 1 $s" );
 file_mode_isnt( 'executable', 0200 );
+test_test();
+}
+
+{
+my $s = Test::File::_win32()
+	? "# skip file_mode_hasnt doesn't work on Windows!"
+	: "- executable mode has no bits of 0200";
+test_out( "ok 1 $s" );
+file_mode_hasnt( 'executable', 0200 );
+test_test();
+}
+
+{
+my $s = Test::File::_win32()
+	? "# skip file_mode_hasnt doesn't work on Windows!"
+	: "- executable mode has no bits of 0111";
+test_out( "not ok 1 $s" );
+test_diag("File [executable] mode has forbidden component 0100!");
+test_diag("  Failed test 'executable mode has no bits of 0111'");
+test_diag("  at " . __FILE__ . " line " . (__LINE__+1) . ".");
+file_mode_hasnt( 'executable', 0111 );
 test_test();
 }
 


### PR DESCRIPTION
(This PR is being filed against my CPAN Pull Request Challenge, but I think these functions are 
genuinely useful.)

This commit adds two new tests which behave like file_mode_is and file_mode_isnt, but do not require an exact match between the wanted and found modes.  Instead, you can just specify a mask that must be entirely present or absent.  I've also added diagnostics that will tell you how you failed, if you failed.  ("You said you need 0110 but you're missing the 0010 part.")

If you think that's all useful, I may give you a follow-up PR to add diagnostics to the _is and _isnt
forms to have diagnostics indicating what you have versus what you want.