### PR TITLE
fix file_mode_h* tests for win32

### DIFF
--- a/t/test_files.t
+++ b/t/test_files.t
@@ -82,14 +82,19 @@ test_test();
 }
 
 {
-my $s = Test::File::_win32()
-	? "# skip file_mode_has doesn't work on Windows!"
-	: "- executable mode has all bits of 0111";
-test_out( "not ok 1 $s" );
-test_diag("File [executable] mode is missing component 0011!");
-test_diag("  Failed test 'executable mode has all bits of 0111'");
-test_diag("  at " . __FILE__ . " line " . (__LINE__+1) . ".");
-file_mode_has( 'executable', 0111 );
+if (Test::File::_win32)
+  {
+    test_out( "ok 1 # skip file_mode_has doesn't work on Windows!" );
+    file_mode_has( 'executable', 0111 );
+  }
+else
+  {
+    test_out( "not ok 1 - executable mode has all bits of 0111" );
+    test_diag("File [executable] mode is missing component 0011!");
+    test_diag("  Failed test 'executable mode has all bits of 0111'");
+    test_diag("  at " . __FILE__ . " line " . (__LINE__+1) . ".");
+    file_mode_has( 'executable', 0111 );
+  }
 test_test();
 }
 
@@ -112,14 +117,19 @@ test_test();
 }
 
 {
-my $s = Test::File::_win32()
-	? "# skip file_mode_hasnt doesn't work on Windows!"
-	: "- executable mode has no bits of 0111";
-test_out( "not ok 1 $s" );
-test_diag("File [executable] mode has forbidden component 0100!");
-test_diag("  Failed test 'executable mode has no bits of 0111'");
-test_diag("  at " . __FILE__ . " line " . (__LINE__+1) . ".");
-file_mode_hasnt( 'executable', 0111 );
+if (Test::File::_win32())
+  {
+    test_out( "ok 1 # skip file_mode_hasnt doesn't work on Windows!" );
+    file_mode_hasnt( 'executable', 0111 );
+  }
+else
+  {
+    test_out( "not ok 1 - executable mode has no bits of 0111" );
+    test_diag("File [executable] mode has forbidden component 0100!");
+    test_diag("  Failed test 'executable mode has no bits of 0111'");
+    test_diag("  at " . __FILE__ . " line " . (__LINE__+1) . ".");
+    file_mode_hasnt( 'executable', 0111 );
+  }
 test_test();
 }
 


### PR DESCRIPTION
On Win32, when we skip the test, we should expect a lot less
output, of course.  Further, skipped tests are "ok" and not
"not ok".