### PR TITLE
Fixes issue #22 : failed tests on MSYS2

### DIFF
--- a/lib/Test/File.pm
+++ b/lib/Test/File.pm
@@ -81,7 +81,7 @@ sub _normalize {
 sub _win32 {
 	return 0 if $^O eq 'darwin';
 	return $ENV{PRETEND_TO_BE_WIN32} if defined $ENV{PRETEND_TO_BE_WIN32};
-	return $^O =~ m/Win/;
+	return $^O =~ m/Win/ || $^O eq 'msys';
 	}
 
 # returns true if symlinks can't exist

--- a/t/file_contains.t
+++ b/t/file_contains.t
@@ -30,6 +30,7 @@ test_test();
 
 SKIP: {
 skip "Superuser has special privileges", 1, if( $> == 0 or $< == 0 );
+skip "Not possible to make file unreadable on MSYS2" if $^O eq 'msys';
 test_out( "not ok 1 - not_readable contains $pattern1" );
 test_diag( 'File [not_readable] is not readable!' );
 test_fail(+1);
@@ -58,6 +59,7 @@ test_test();
 
 SKIP: {
 skip "Superuser has special privileges", 1, if( $> == 0 or $< == 0 );
+skip "Not possible to make file unreadable on MSYS2" if $^O eq 'msys';
 test_out( "not ok 1 - not_readable doesn't contain $bad_pattern" );
 test_diag( 'File [not_readable] is not readable!' );
 test_fail(+1);
@@ -92,6 +94,7 @@ test_test();
 
 SKIP: {
 skip "Superuser has special privileges", 1, if( $> == 0 or $< == 0 );
+skip "Not possible to make file unreadable on MSYS2" if $^O eq 'msys';
 test_out( "not ok 1 - not_readable contains $pattern1" );
 test_diag( 'File [not_readable] is not readable!' );
 test_fail(+1);
@@ -127,6 +130,7 @@ test_test();
 
 SKIP: {
 skip "Superuser has special privileges", 1, if( $> == 0 or $< == 0 );
+skip "Not possible to make file unreadable on MSYS2" if $^O eq 'msys';
 test_out( "not ok 1 - not_readable doesn't contain $bad_pattern" );
 test_diag( 'File [not_readable] is not readable!' );
 test_fail(+1);

--- a/t/test_files.t
+++ b/t/test_files.t
@@ -80,6 +80,7 @@ subtest readable_fails => sub { SKIP: {
 
 subtest not_readable_fails => sub { SKIP: {
 	skip "Superuser has special privileges", 3, if( $> == 0 or $< == 0 );
+	skip "Not possible to make file unreadable on MSYS2" if $^O eq 'msys';
 	test_out( 'ok 1 - writeable is not readable' );
 	file_not_readable_ok( 'writeable' );
 	test_out( 'ok 2 - writeable really is not readable' );
@@ -115,6 +116,7 @@ subtest writable_fails => sub {
 
 subtest not_writable => sub { SKIP: {
 	skip "Superuser has special privileges", 1, if( $> == 0 or $< == 0 );
+	skip "Not possible to make file unreadable on MSYS2" if $^O eq 'msys';
 	test_out( 'ok 1 - readable is not writable' );
 	test_out( 'not ok 2 - writable is not writable' );
 	test_diag('File [writable] is writable!');
@@ -128,9 +130,9 @@ subtest not_writable => sub { SKIP: {
 
 subtest executable => sub {
 	if (Test::File::_win32()) {
-		test_out("ok 1 # skip file_not_executable_ok doesn't work on Windows!");
-		test_out("ok 2 # skip file_not_executable_ok doesn't work on Windows!");
-		test_out("ok 3 # skip file_not_executable_ok doesn't work on Windows!");
+		test_out("ok 1 # skip file_executable_ok doesn't work on Windows!");
+		test_out("ok 2 # skip file_executable_ok doesn't work on Windows!");
+		test_out("ok 3 # skip file_executable_ok doesn't work on Windows!");
 		}
 	else {
 		test_out("ok 1 - executable is executable");

--- a/t/test_files.t
+++ b/t/test_files.t
@@ -100,7 +100,7 @@ subtest writable_fails => sub {
 	file_writable_ok( 'writable' );
 	test_out( "ok 2 - $label" );
 	file_writable_ok( 'writable', $label );
-	if( $> == 0 or $< == 0 ) {
+	if( ($^O ne 'MSWin32') && ($> == 0 or $< == 0 )) {
 		test_out( 'ok 3 - readable is writeable' );
 		}
 	else {


### PR DESCRIPTION
Fixes issue #22. It seems it is not possible to make files unreadable on MSYS2. Skipped the tests that checked for readable bit. Also added 'msys' to the `_win32()` sub such that MSYS2 is treated as Win32 in the tests. The test suite now passes on my machine.