### PR TITLE
t/test_files.t fails on Cygwin

### DIFF
--- a/t/test_files.t
+++ b/t/test_files.t
@@ -102,7 +102,7 @@ subtest writable_fails => sub {
 	file_writable_ok( 'writable' );
 	test_out( "ok 2 - $label" );
 	file_writable_ok( 'writable', $label );
-	if( is_cygwin() or is_unix_superuser() ) {
+	if( is_unix_superuser() ) {
 		test_out( 'ok 3 - readable is writable' );
 		}
 	else {


### PR DESCRIPTION
This is a request to fix: http://www.cpantesters.org/cpan/report/f14d2063-6f7b-1014-a9dc-48cf75d8a230

https://github.com/briandfoy/test-file/blob/ee9265cae4762d0ff0e5eaca9d7670d3966b121b/t/test_files.t#L105-L107

The above code seems to say "Any Cygwin users can write to readable-only file (permission 0400) like UNIX superuser", but actually it's not true.
```
$ cygcheck -c cygwin

Cygwin Package Information
Package              Version        Status
cygwin               3.1.7-1        OK

$ touch readable
$ chmod 0400 readable
$ echo 1 > readable
bash: readable: Permission denied
```