### PR TITLE
Get can_symlink from lib

### DIFF
--- a/t/links.t
+++ b/t/links.t
@@ -4,7 +4,7 @@ use Test::Builder::Tester;
 use Test::More 1;
 use Test::File;
 
-my $can_symlink = eval { symlink("",""); 1 };
+my $can_symlink = !Test::File::_no_symlinks_here();
 
 plan skip_all => "This system does't do symlinks" unless $can_symlink;
 


### PR DESCRIPTION
Test is ok if `t\links.t` gets the information from the method that you modified in `lib\Test\File.pm`.
I hope (though I guess as far as I understand the modif) that the other platforms are not affected.